### PR TITLE
Define username in a single place

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,10 @@ jobs:
         environment:
           RAILS_ENV: test
           PGHOST: 127.0.0.1
-          PGUSER: root
+          PGUSER: expiration
       - image: circleci/postgres:12.4
         environment:
-          POSTGRES_USER: root
+          POSTGRES_USER: expiration
           POSTGRES_PASSWORD: $POSTGRES_PASSWORD
           POSTGRES_DB: expiration_test
     steps:

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,11 +2,11 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: 5
+  username: expiration
 
 development:
   <<: *default
   database: expiration_development
-  username: expiration
 
 test:
   <<: *default
@@ -15,5 +15,4 @@ test:
 production:
   <<: *default
   database: expiration_production
-  username: expiration
   password: <%= ENV['EXPIRATION_DATABASE_PASSWORD'] %>


### PR DESCRIPTION
Locally, this avoids 'role "siggy" does not exist'.