### PR TITLE
Remove omniauth exceptions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,3 @@ updates:
     interval: daily
     time: "09:00"
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: omniauth
-    versions:
-    - 2.0.1
-    - 2.0.2
-    - 2.0.3


### PR DESCRIPTION
With the merge of https://github.com/siegfault/expiration/pull/578, we
no longer need to ignore this within dependabot (probably shouldn't have
in the first place).